### PR TITLE
Add bug traiaging section

### DIFF
--- a/thunderbird-development/bug-triaging/README.md
+++ b/thunderbird-development/bug-triaging/README.md
@@ -1,0 +1,44 @@
+---
+description: Tutorial on how to dive into triaging bugs.
+---
+
+How to efficiently triage bugs and contribute to a clean and organized Bugzilla
+
+# Expectations
+The best way to optimize your time and drive a productive triaging session is to set limited expectations, and only tackle a limited amount of bugs per day. It’s easy to feel overwhelmed after triaging 10 bugs (some of which may be difficult) and seeing that in the meantime 50 more bugs have been reported.
+
+Try to manage your expectations and accept that what you are doing, as small as it can look, is important and vital for the success of Thunderbird.
+
+# Requirements
+Not all of these are hard requirements, but some nice to have configurations that will make it easier to triage complex reports.
+
+Have the ability to test on all the Operating Systems (bare metal or VMs), and should not be blocked by technical limitations as much as possible.
+Run all currently supported versions (Daily, Beta, ESR).
+Ability to run [moz-regression](https://mozilla.github.io/mozregression/) and familiarity with the tool.
+
+# Rules of the Road
+
+* **Always be respectful** and polite even when faced with a difficult reporter, because a) this is a customer facing environment, b) being empathetic is healthy for both you and the reporter. Doesn’t mean you have to engage with impolite reporters or accept abuse (see 3rd point below). *“Thank you”*, and *“please”*, and similar ideas go a long way to encouraging users to engage and return.
+* **Acknowledge the issue**, e.g.: *“I’m sorry you are having some issues, could you please provide me with the following information so that I can look into it…”*
+* **Don’t accept harassment** from a reporter, if they violate our community rules mark the comment as abuse and close the bug as invalid.
+  * If the bug is a real issue, recreate it in a new bug. Allowing abuse in Bugzilla sets a bad precedent and is unhealthy for everyone involved and the entire community.
+  * *E.g.: “You guys are idiots. This is disgusting. The Thunderbird Team/you are stupid”.*
+* Do not drive users against developers, and do not argue with other team members in a bug. The MZLA team is to always have a united front on Bugzilla.
+  * *E.g. Triager finds the regression and pulls in the developer. Developer says that it was intended that this feature would work differently (or is now unsupported).*
+  * *Another core developer joins the conversation and publicly disagrees with the previous developer’s statement.*
+  * ***Don’t argue in the bug - take it to another internal forum to discuss, come back with a united front on how to proceed.***
+* **Don’t promote your own point of view.** A triager should be unbiased - is it a bug? Is it reproducible? That’s it.
+* **Do not try to create a solution to the bug.** Leave the ideation and implementation of a solution to the developers, designers, and product management as there are likely many considerations that go into a resolution.
+* **Stay neutral and take a step back when things are hard to handle.** We have 20 million users, lots of bugs and lots of negativity will come in. A bug report comes from an emotional reaction, likely a negative experience. You need to detach from the emotional aspect of any bug and not escalate emotions, but also not take it as a personal attack.
+
+# How to triage
+* **Don’t triage bugs that you have no idea what they are.** Stick to your area of expertise!
+  * If you’re in the back-end, don’t try to triage front-end bugs, and vice versa.
+  * No need to add noise to bugs if you have no clue what the topic or context is.
+* **Stick to your strengths** and to the areas you worked on. Participate in the bugs that you know what the reporter is talking about and you have historical knowledge of that area.
+* **Point users to KB articles** so they learn to use them, and hopefully are then less likely to report things that are not bugs and more likely to make good bug reports. 
+  * Examples: [Troubleshoot Mode](https://support.mozilla.org/en-US/kb/cannot-receive-messages), [not receiving messages](https://support.mozilla.org/en-US/kb/cannot-receive-messages) - in general items under https://support.mozilla.org/en-US/products/thunderbird/fix-slowness-crashing-error-messages-and-other-problems.  (If an existing article is inaccurate, please ping Roland, Heather, or Wayne to get to get it updated) 
+* Try to first reproduce the issue reported.
+* **Try to add all the flags and data points in one go** in order to limit email noise for all the people CC’ed on those bugs.
+* **Don’t let your time go to waste**. If you have read a bug but are unable to confirm or add significant info (you can’t reproduce, etc) - at a minimum: assign a component, a better summary, or NI or CC someone who can take a next step.
+

--- a/thunderbird-development/bug-triaging/bug-status-classification.md
+++ b/thunderbird-development/bug-triaging/bug-status-classification.md
@@ -1,0 +1,25 @@
+# Bug Status Classification
+When setting a bug priority and severity classification, note that you can click on Priority in the Category section to go to [the mozilla page with the different levels](https://wiki.mozilla.org/BMO/UserGuide/BugFields#priority) and when to set them.
+
+## The Bug is REPRODUCIBLE
+* Move the bug into the **correct component** if it’s not already there.
+* Mark it as **NEW** if it’s still **UNCONFIRMED**.
+* Add the **triaged** keyword (that will require a severity level).
+* Set **Priority** and **Severity** if you feel comfortable, or ask a manager or module owner to help you define those.
+* Add **other keywords** if relevant (ux, access, perf, etc.).
+* If it’s a **regression**, try to find the bug that regressed that feature and add it along with the REGRESSION keyword. [https://mozilla.github.io/mozregression/](https://mozilla.github.io/mozregression/) is a good tool for you and reporters.
+  * If you can’t find a regression, add the **regressionwindow-wanted** keyword.
+
+## The Bug is NOT REPRODUCIBLE
+* Ask the reporter to try in [troubleshoot mode]() without any add-on.
+* Ask for more info if not already provided, like OS or their particular setup.
+* Try to get more clear instructions - users tend to understand better if they are asked to make a list of actions or clicks they used.
+* DON’T simply write “It works for me”, that’s not helpful and it’s just noise, and it can increase the frustration of the reporter.
+* Issues are very situational, as they might be caused by errors in C++, JavaScript, translation, a custom configuration from the user, or many other things.
+  * For instances in which a tab is blank or something doesn’t load as expected, ask the user to check the Error Console and report any messages in there (ctrl+shift+J or cmd+shift+J for macOS)
+
+## The Bug is a DUPLICATE
+* Bugzilla does a terrible job of suggesting potential duplicates when the user files a bug, so you will stumble upon the same issue reported by different users.
+* Try to identify the duplicates and close them by adding the original bug that we use as a reference. Please give a reason for duping, a) to educate the user, b) so user doesn’t feel like we are just closing bugs and brushing them off.  Boilerplate text:
+  * This issue is being investigated in bug XXXX.  If you think that bug is missing important information that will help lead to fixing or reproducing it, please add it to that bug.
+

--- a/thunderbird-development/bug-triaging/bug-types.md
+++ b/thunderbird-development/bug-triaging/bug-types.md
@@ -1,0 +1,13 @@
+## The Bug Type is Enhancement, Bug, or Task
+
+A bug report can be of 3 different types
+
+1. **Enhancement**
+Bugs that are requests for new features, or modifications of existing features. Reports that the user thinks might be incorrect behavior could be classified as bugs, but if that feature behaves as intended, the request is not a bug but a RFE (Request for Enhancement).
+
+2. **Bug/Defect**
+Broken functionality, not working properly, crashes, and pretty much anything that is not working as expected.
+
+3. **Task**
+Limit the use of Task to meta bugs or internal efforts related to code clean up, architectural restructuring, tests or telemetry implementation. If it affects a user of a current release, it is better categorized as a Bug.
+

--- a/thunderbird-development/bug-triaging/garbage-collection.md
+++ b/thunderbird-development/bug-triaging/garbage-collection.md
@@ -1,0 +1,10 @@
+## Garbage collection
+
+You will see bugs that have been around for years and received very little activity, or bugs that were originally opened as means to track new features, but went out of scope as the overall direction of the project changed.
+
+Closing those bugs will help clean up our Bugzilla searches and keep things more organized.
+
+* Features request (RFE) that are outside our current or future scope.
+* Bugs that don’t apply anymore (E.g. old address book issues, UI that has been replaced).
+* Bugs left open with the intention of one day fixing it, but do not align with our scope.
+

--- a/thunderbird-development/bug-triaging/narrow-the-scope.md
+++ b/thunderbird-development/bug-triaging/narrow-the-scope.md
@@ -1,0 +1,4 @@
+## All Bugs - improve searchability and accuracy / narrow the scope 
+* **Set an accurate version number**, the earliest possible/likely version where it reproduces is ideal (eg. the version # of the bug causing the regression). “Trunk” or “unspec” should be changed to an actual number.
+* **OS** should be set if the issue is OS specific. (also add to the bug summary as a keyword, eg. “Mac”)
+* **Summary is key.**  Improving the summary speeds up understandability and searchability - your improvement can save everyone valuable time. 1) remove extraneous words. 2) add key words that express how the user experiences the issue. 3) add technical/coding info if appropriate, but never remove user symptoms from the summary.


### PR DESCRIPTION
This change is just adding the extensive bug triaging document (developed internally) to the developer website.