### PR TITLE
Update build instructions related to Linux and overall builds

### DIFF
--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -7,7 +7,7 @@ description: How to build and run Thunderbird.
 ## Hardware Requirements
 
 * At least **4 GB of RAM**. 8 GB or more is recommended. While you can build Thunderbird on older hardware it can take quite a bit of time to compile on slower machines with less RAM.
-* 30 GB of free space. The Thunderbird build can use 30-40GB of disk space to complete depending on your operating system.
+* 30 GB of free space. The Thunderbird build can use up to 30-40GB of disk space to complete depending on your operating system.
 * Good internet connection for the initial source download.
 
 ## Build Prerequisites

--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -20,7 +20,7 @@ Depending on your Operating System you will need to carry out a different proces
 
 ## Build Configuration
 
-To build Thunderbird, you need a file named `mozconfig` in the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. If you do not already have this file, then you can create a file with this line by doing this in the `source/` directory:
+To build Thunderbird, you need a file named `mozconfig` in the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. If you do not already have this file, then you can create it with this line by doing this in the `source/` directory:
 
 ```
 echo 'ac_add_options --enable-project=comm/mail' > mozconfig

--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -7,11 +7,12 @@ description: How to build and run Thunderbird.
 ## Hardware Requirements
 
 * At least **4 GB of RAM**. 8 GB or more is recommended. While you can build Thunderbird on older hardware it can take quite a bit of time to compile on slower machines with less RAM.
+* 30 GB of free space. The Thunderbird build will take up to 30 GB of disk space in order to complete.
 * Good internet connection for the initial source download.
 
 ## Build Prerequisites
 
-Depending on your Operating System you will need to carry out a different process to prepare your machine. So firstly complete the instructions for your OS and then continue following these build instructions.
+Depending on your Operating System you will need to carry out a different process to prepare your machine. So first complete the instructions for your OS and then continue following these build instructions.
 
 * [Windows Build Prerequisites](windows-build-prerequisites.md)
 * [Linux Build Prerequisites](linux-build-prerequisites.md)
@@ -19,7 +20,7 @@ Depending on your Operating System you will need to carry out a different proces
 
 ## Build Configuration
 
-To build Thunderbird, you need to create a file named `mozconfig` in the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. You can create a file with this line by doing this in the `source/` directory:
+To build Thunderbird, you need a file named `mozconfig` in the root directory of the mozilla-central checkout that contains the option `comm/mail` enabled. If you do not already have this file, then you can create a file with this line by doing this in the `source/` directory:
 
 ```
 echo 'ac_add_options --enable-project=comm/mail' > mozconfig

--- a/thunderbird-development/building-thunderbird/README.md
+++ b/thunderbird-development/building-thunderbird/README.md
@@ -7,7 +7,7 @@ description: How to build and run Thunderbird.
 ## Hardware Requirements
 
 * At least **4 GB of RAM**. 8 GB or more is recommended. While you can build Thunderbird on older hardware it can take quite a bit of time to compile on slower machines with less RAM.
-* 30 GB of free space. The Thunderbird build will take up to 30 GB of disk space in order to complete.
+* 30 GB of free space. The Thunderbird build can use 30-40GB of disk space to complete depending on your operating system.
 * Good internet connection for the initial source download.
 
 ## Build Prerequisites

--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -36,7 +36,7 @@ You will also need `python3-distutils` and `python3-pip` installed from your dis
 
 ## Mercurial
 
-As noted in the [Getting Started page](../getting-started#mercurial-version-control), both `mozilla-central` and `comm-central` are version controlled with Mercurial. This means you will need to install Mercurial.
+As noted in the [Getting Started page](../getting-started#mercurial-version-control), both `mozilla-central` and `comm-central` are repositories using the Mercurial version control system. This means you will need to install Mercurial.
 Here are the quick commands to use for common Linux based operating systems but for a more complete list of instructions (if neither of these works for your use case), please see [Mercurial's download page on their wiki](https://www.mercurial-scm.org/wiki/Download).
 
 ### Ubuntu/Debian

--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -59,7 +59,7 @@ Mozilla-central will build Firefox without the comm-central repo present and a f
 
 ## Scripted
 
-We have created and host a script that will grab the two source repos you need, run `./mach bootstrap` for you, and sets up a necessary `mozconfig` file. This script is called [`bootstrap.py`](https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py). Download this file to the directory where you would like your source code folder to live, either by clicking the link and moving the file to the appropriate location or using `wget`. Then we will make it executable and run it.
+We have created and host a script that will grab the two source repos you need, run `./mach bootstrap` for you, and sets up a necessary `mozconfig` file. This script is called [`bootstrap.py`](https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py). Download this file to the directory where you would like your source code folder to live, either by clicking the link and moving the file to the appropriate location or using `wget`. Then make it executable and run it.
 
 ```
 mkdir tb-build && cd tb-build

--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -21,7 +21,7 @@ if this command returns `x86_64` you can proceed.
 The Thunderbird build can use 30-40GB of disk space to complete depending on your operating system.
 
 {% hint style="warning" %}
-Note that while it's not technically required to have an internet connection to build, the default when building from `mozilla/comm-central` is that `--enable-bootstrap` is set so that the toolchains download automatically. If you do not have an active internet connection then 
+Note that while it's not technically required to have an internet connection to build, the default setup has `--enable-bootstrap` so that the toolchains download automatically.
 {% endhint %}
 
 # Build Environment
@@ -87,6 +87,10 @@ cd source/
 hg clone https://hg.mozilla.org/comm-central comm/
 ```
 
+### Create `mozconfig` file
+
+This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
+
 ## Mach Bootstrap
 In the `source` directory run the following command to get additional dependencies needed to install Thunderbird:
 
@@ -107,10 +111,6 @@ Please choose the version of Firefox you want to build:
 Please choose option 2 to proceed with a successful build.
 
 This action should install all the remaining libraries and dependencies necessary to build Thunderbird locally.
-
-### Create `mozconfig` file
-
-This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
 
 ## Missing libraries
 

--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -18,7 +18,11 @@ if this command returns `x86_64` you can proceed.
 
 ## 30 GB of free space
 
-The Thunderbird build will take up to 30 GB of disk space in order to complete. Be sure to have enough free space and a fast internet connection to avoid interruptions.
+The Thunderbird build can use 30-40GB of disk space to complete depending on your operating system.
+
+{% hint style="warning" %}
+Note that while it's not technically required to have an internet connection to build, the default when building from `mozilla/comm-central` is that `--enable-bootstrap` is set so that the toolchains download automatically. If you do not have an active internet connection then 
+{% endhint %}
 
 # Build Environment
 
@@ -48,6 +52,10 @@ sudo dnf install mercurial
 # Getting the Code
 
 Once you have Mercurial installed, you are ready to grab the source code. There are a couple of different methods to do this.
+
+{% hint style="warning" %}
+Mozilla-central will build Firefox without the comm-central repo present and a few options set. Mozilla-central is the Firefox codebase and comm-central features the additions that turn Firefox into Thunderbird.
+{% endhint %}
 
 ## Scripted
 
@@ -79,7 +87,7 @@ cd source/
 hg clone https://hg.mozilla.org/comm-central comm/
 ```
 
-### Mach Bootstrap
+## Mach Bootstrap
 In the `source` directory run the following command to get additional dependencies needed to install Thunderbird:
 
 ```
@@ -98,9 +106,13 @@ Please choose the version of Firefox you want to build:
 
 Please choose option 2 to proceed with a successful build.
 
-This action will install all the remaining libraries and dependencies necessary to build Thunderbird locally.
+This action should install all the remaining libraries and dependencies necessary to build Thunderbird locally.
 
-# Missing libraries
+### Create `mozconfig` file
+
+This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
+
+## Missing libraries
 
 It could happen that some libraries will not be installed by the `bootstrap` command, specifically those related to the `Rust` programming language. Check whether these packages are available in your system by running these commands in your terminal:
 
@@ -124,7 +136,7 @@ export PATH=$HOME/.cargo/bin:$PATH
 If you still are unable to find rustc and cargo via the ˋwhichˋ command after installing them, you may need to restart your session (log out and back into your user account, or restart your computer) to be able to see them.
 {% endhint %}
 
-## You're all set
+# You're all set
 
 Go back to the [Building Thunderbird](./#build-configuration) page and continue following the guide.
 

--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -4,13 +4,11 @@ description: >-
   environment set up and ready to hack on Thunderbird.
 ---
 
-# Linux Build Prerequisites
-
-This guide assumes you already followed the [Getting Started](../getting-started.md) documentation and you already downloaded `mozilla-central` and `comm-central` source code.
+# Hardware Requirements
 
 ## 64-bit version
 
-You need a 64 bit version of Linux in order to build Thunderbird. You can check which version you're running by typing this command in your terminal:
+You will need to be running a 64-bit version of Linux in order to build Thunderbird. You can check which version you're running by typing this command in your terminal:
 
 ```
 uname -m
@@ -18,27 +16,77 @@ uname -m
 
 if this command returns `x86_64` you can proceed.
 
+## 30 GB of free space
+
+The Thunderbird build will take up to 30 GB of disk space in order to complete. Be sure to have enough free space and a fast internet connection to avoid interruptions.
+
+# Build Environment
+
 ## Python
 
-You’ll need `Python 3.6` or later installed.
+You’ll need `Python 3.8` or later installed.
 
 You can check with `python3 --version` to see if you have it already. If not, you can install it with your distribution’s package manager. Make sure your system is up to date!
 
 You will also need `python3-distutils` and `python3-pip` installed from your distribution's package manager.
 
-## 30 GB of free space
+## Mercurial
 
-The Thunderbird build will take up to 30 GB of disk space in order to complete. Be sure to have enough free space and a fast internet connection to avoid interruptions.
+As noted in the [Getting Started page](../getting-started#mercurial-version-control), both `mozilla-central` and `comm-central` are version controlled with Mercurial. This means you will need to install Mercurial.
+Here are the quick commands to use for common Linux based operating systems but for a more complete list of instructions (if neither of these works for your use case), please see [Mercurial's download page on their wiki](https://www.mercurial-scm.org/wiki/Download).
 
-## Bootstrap your system
+### Ubuntu/Debian
+```
+sudo apt install mercurial
+```
 
-Access the location where you downloaded the `mozilla-central` source code, most likely `source/` and trigger this command:
+### Fedora
+```
+sudo dnf install mercurial
+```
+
+# Getting the Code
+
+Once you have Mercurial installed, you are ready to grab the source code. There are a couple of different methods to do this.
+
+## Scripted
+
+We have created and host a script that will grab the two source repos you need, run `./mach bootstrap` for you, and sets up a necessary `mozconfig` file. This script is called [`bootstrap.py`](https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py). Download this file to the directory where you would like your source code folder to live, either by clicking the link and moving the file to the appropriate location or using `wget`. Then we will make it executable and run it.
+
+```
+mkdir tb-build && cd tb-build
+wget https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py
+chmod +x bootstrap.py
+./bootstrap.py
+```
+
+This will create a `mozilla-unified` directory with both a `mozconfig` and a `comm/` folder inside. The `mozconfig` file is setup to build Thunderbird and you can verify this with `cat mozconfig`; the `--enable-project` parameter should be `comm/mail`:
+
+```
+ac_add_options --enable-project=comm/mail
+```
+
+## Manually
+
+If you would rather manually gather the source code, perform the bootstrap, and create your `mozconfig` file, then follow these steps.
+
+### Checkout the Source Code
+Get the latest Mozilla source code from Mozilla's `mozilla-central` Mercurial code repository, and check it out into a local directory `source` (or however you want to call it). Then, get the latest Thunderbird source code from Mozilla's `comm-central` Mercurial code repository. It needs to be placed **inside** the Mozilla source code, in a directory named `comm/`:
+
+```
+hg clone https://hg.mozilla.org/mozilla-central source/
+cd source/
+hg clone https://hg.mozilla.org/comm-central comm/
+```
+
+### Mach Bootstrap
+In the `source` directory run the following command to get additional dependencies needed to install Thunderbird:
 
 ```
 ./mach bootstrap
 ```
 
-You will be asked to choose from the following list of options
+You will be presented with the following options:
 
 ```
 Please choose the version of Firefox you want to build:
@@ -50,9 +98,9 @@ Please choose the version of Firefox you want to build:
 
 Please choose option 2 to proceed with a successful build.
 
-This action will install all the libraries and dependencies necessary to build Thunderbird locally.
+This action will install all the remaining libraries and dependencies necessary to build Thunderbird locally.
 
-### Missing libraries
+# Missing libraries
 
 It could happen that some libraries will not be installed by the `bootstrap` command, specifically those related to the `Rust` programming language. Check whether these packages are available in your system by running these commands in your terminal:
 
@@ -78,7 +126,7 @@ If you still are unable to find rustc and cargo via the ˋwhichˋ command after 
 
 ## You're all set
 
-Got back to the [Building Thunderbird](./#build-configuration) page and continue following the guide.
+Go back to the [Building Thunderbird](./#build-configuration) page and continue following the guide.
 
 {% content-ref url="./" %}
 [.](./)

--- a/thunderbird-development/building-thunderbird/macos-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/macos-build-prerequisites.md
@@ -82,6 +82,10 @@ cd source/
 hg clone https://hg.mozilla.org/comm-central comm/
 ```
 
+### Create `mozconfig` file
+
+This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
+
 ### Mach Bootstrap
 In the `source` directory run the following command to get additional dependencies needed to install Thunderbird:
 
@@ -102,10 +106,6 @@ Please choose the version of Firefox you want to build:
 Please choose option 2 to proceed with a successful build.
 
 This action should install all the remaining libraries and dependencies necessary to build Thunderbird locally.
-
-### Create `mozconfig` file
-
-This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
 
 ## Missing libraries
 

--- a/thunderbird-development/getting-started.md
+++ b/thunderbird-development/getting-started.md
@@ -6,11 +6,14 @@ description: >-
 
 # Getting Started
 
-## What You Need to Know
+## Build Prerequisites
+Before you can build Thunderbird, please follow your platform's build prerequisites page:
 
-### Mozilla Code Base
+* [Windows Build Prerequisites](windows-build-prerequisites.md)
+* [Linux Build Prerequisites](linux-build-prerequisites.md)
+* [macOS Build Prerequisites](macos-build-prerequisites.md)
 
-Thunderbird is built on the Mozilla platform, the same base that Firefox is built from. As such the two projects share a lot of code and much of the documentation for one will apply, in many ways, to the other. If at any point you are looking for answers that you can't find here, try looking at [Mozilla's Developer site called: **MDN**](https://developer.mozilla.org). Another good resource is [Firefox Source Tree Documentation](https://firefox-source-docs.mozilla.org/).
+## General Information
 
 ### Mercurial Version Control
 
@@ -18,35 +21,25 @@ Mozilla uses the [Mercurial version control](https://www.mercurial-scm.org/) sof
 
 Information for how to install Mercurial is available [via the download page on their wiki](https://www.mercurial-scm.org/wiki/Download).
 
-## Get the Source
+### Mozilla Code Base
 
-{% hint style="warning" %}
-The source code requires 3.6GB of free space or more and additionally 5GB or more for default build.
-{% endhint %}
+#### mozilla-central vs. comm-central
 
-{% hint style="danger" %}
-**For Windows Users:** If you are using Windows, you will want to follow instructions on the Windows Build Prerequisities page before getting the source and building Thunderbird.
-{% endhint %}
+The latest Mozilla source code comes from Mozilla's `mozilla-central` Mercurial code repository, often called `source/` but it can be named anything you like. The latest Thunderbird source code comes from Mozilla's `comm-central` Mercurial code repositoryand needs to be placed **inside** the Mozilla source code, in a directory that must be named `comm/`.
 
-{% content-ref url="building-thunderbird/windows-build-prerequisites.md" %}
-[windows-build-prerequisites.md](building-thunderbird/windows-build-prerequisites.md)
-{% endcontent-ref %}
+Mozilla-central will build Firefox without the comm-central repo present and a few options set (detailed on the [Building Thunderbird](building-thunderbird/) page).
 
-Get the latest Mozilla source code from Mozilla's `mozilla-central` Mercurial code repository, and check it out into a local directory `source` (or however you want to call it). Then, get the latest Thunderbird source code from Mozilla's `comm-central` Mercurial code repository. It now needs to be placed **inside** the Mozilla source code, in a directory named `comm/`:
+### Additional Documentation 
 
-```
-hg clone https://hg.mozilla.org/mozilla-central source/
-cd source/
-hg clone https://hg.mozilla.org/comm-central comm/
-```
+Thunderbird is built on the Mozilla platform, the same base that Firefox is built from. As such the two projects share a lot of code and much of the documentation for one will apply, in many ways, to the other. If at any point you are looking for answers that you can't find here, here are some additional useful resources:
 
-### mozilla-central vs. comm-central
-
-Mozilla-central will build Firefox without the comm-central repo present and a few options set (detailed on the [Building Thunderbird](building-thunderbird/) page). Mozilla-central is the Firefox codebase and comm-central features the additions that turn Firefox into Thunderbird.
+* [Thunderbird Source Tree Documentation](https://source-docs.thunderbird.net)
+* [Firefox Source Tree Documentation](https://firefox-source-docs.mozilla.org/)
+* [Mozilla's Developer site called: **MDN**](https://developer.mozilla.org)
 
 ## What's Next
 
-Let's build the latest Thunderbird:
+If you have already gone through the relevant build prerequisite steps, then let's build the latest Thunderbird:
 
 {% content-ref url="building-thunderbird/" %}
 [building-thunderbird](building-thunderbird/)


### PR DESCRIPTION
These changes aim to update the Getting Started page, Building Thunderbird page, and the specific build instructions for both Linus and Mac. 

This PR is meant as a replacement for the app.gitbook.com change request "#639: Fix up Mac + Linux build instructions", simply because this PR workflow is much smoother.

Fixes #178 