### PR TITLE
Fixed the build prerequisite links on getting started page

### DIFF
--- a/thunderbird-development/getting-started.md
+++ b/thunderbird-development/getting-started.md
@@ -9,9 +9,9 @@ description: >-
 ## Build Prerequisites
 Before you can build Thunderbird, please follow your platform's build prerequisites page:
 
-* [Windows Build Prerequisites](windows-build-prerequisites.md)
-* [Linux Build Prerequisites](linux-build-prerequisites.md)
-* [macOS Build Prerequisites](macos-build-prerequisites.md)
+* [Windows Build Prerequisites](building-thunderbird/windows-build-prerequisites.md)
+* [Linux Build Prerequisites](building-thunderbird/linux-build-prerequisites.md)
+* [macOS Build Prerequisites](building-thunderbird/macos-build-prerequisites.md)
 
 ## General Information
 


### PR DESCRIPTION
The build pre-requisite links were pointing to the wrong location and giving a 404.