### PR TITLE
Improve description of bootstrap.py in Linux build prerequisites

### DIFF
--- a/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
+++ b/thunderbird-development/building-thunderbird/linux-build-prerequisites.md
@@ -59,7 +59,7 @@ Mozilla-central will build Firefox without the comm-central repo present and a f
 
 ## Scripted
 
-We have created and host a script that will grab the two source repos you need, run `./mach bootstrap` for you, and sets up a necessary `mozconfig` file. This script is called [`bootstrap.py`](https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py). Download this file to the directory where you would like your source code folder to live, either by clicking the link and moving the file to the appropriate location or using `wget`. Then make it executable and run it.
+The [`bootstrap.py`](https://hg.mozilla.org/comm-central/raw-file/tip/python/rocboot/bin/bootstrap.py) script will grab the two source repos you need, run `./mach bootstrap` for you, and sets up a necessary `mozconfig` file. Download this file to the directory where you would like your source code folder to live, either by clicking the link and moving the file to the appropriate location or using `wget`. Then make it executable and run it.
 
 ```
 mkdir tb-build && cd tb-build
@@ -89,7 +89,7 @@ hg clone https://hg.mozilla.org/comm-central comm/
 
 ### Create `mozconfig` file
 
-This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbire](./#build-configuration).
+This step will need to be performed if you manually checked out the code and performed the bootstrap, and it will covered in the next section you follow, [Building Thunderbird](./#build-configuration).
 
 ## Mach Bootstrap
 In the `source` directory run the following command to get additional dependencies needed to install Thunderbird:


### PR DESCRIPTION
The description of the `bootstrap.py` script felt surprising to me because it starts by mentioning all the steps it does before mentioning the script itself.

It seems to be written from the perspective of the author of the script ("we have created and host…") rather than from the perspective of a new contributor, who doesn't know what those steps are in the first place (and doesn't care so much about the creation and hosting of the script itself). The wording I am proposing feels more natural in that respect.