### PR TITLE
Update README header links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,13 @@ Description: >-
 
 This page has some information on how to get plugged into the Community. If you are ready to start hacking, head over to one of the following sections.
 
-### Contributing to Thunderbird
+### [Contributing to Thunderbird](thunderbird-development/getting-started.md)
 
 Get all the information you need to set up your development environment and get ready to hack on Thunderbird.
 
-{% page-ref page="thunderbird-development/getting-started.md" %}
-
-### Add-on Development
+### [Add-on Development](add-ons/about-add-ons.md)
 
 If you'd like to learn to develop add-ons for Thunderbird, check out our add-on documentation with examples, tips and links to relevant resources.
-
-{% page-ref page="add-ons/about-add-ons.md" %}
 
 ## Report Bugs and Request Features
 


### PR DESCRIPTION
## Summary

It seems that the `Contributing to Thunderbird` and `Add-on Development` header links in the main README.md of the repo are not following the [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) while linking pages as I assume that the previous pattern was done through GitBook based off of the [commit that previously made this change](https://github.com/thunderbird/developer-docs/commit/aecba8bac0e30556f8f6b4b76784b51d5d547bb9).

## Changes

Considering that the intention was to links to other internal markdown pages located in `thunderbird-development/getting-started.md` and `add-ons/about-add-ons.md` respectively, I've changed them to use the `[]()` syntax instead.